### PR TITLE
fix(video): restore missing framerateX100 in encoder probe configs

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2995,8 +2995,8 @@ namespace video {
     encoder.av1.capabilities.set();
 
     // First, test encoder viability
-    config_t config_max_ref_frames {1920, 1080, 60, 1000, 1, 1, 1, 0, 0, 0};
-    config_t config_autoselect {1920, 1080, 60, 1000, 1, 0, 1, 0, 0, 0};
+    config_t config_max_ref_frames {1920, 1080, 60, 6000, 1000, 1, 1, 1, 0, 0, 0};
+    config_t config_autoselect {1920, 1080, 60, 6000, 1000, 1, 0, 1, 0, 0, 0};
 
     // If the encoder isn't supported at all (not even H.264), bail early
     // Try to reuse cached display if same device type
@@ -3099,14 +3099,14 @@ namespace video {
     {
       // H.264 is special because encoders may support YUV 4:4:4 without supporting 10-bit color depth
       if (encoder.flags & YUV444_SUPPORT) {
-        config_t config_h264_yuv444 {1920, 1080, 60, 1000, 1, 0, 1, 0, 0, 1};
+        config_t config_h264_yuv444 {1920, 1080, 60, 6000, 1000, 1, 0, 1, 0, 0, 1};
         encoder.h264[encoder_t::YUV444] = disp->is_codec_supported(encoder.h264.name, config_h264_yuv444) &&
                                           validate_config(disp, encoder, config_h264_yuv444) >= 0;
       } else {
         encoder.h264[encoder_t::YUV444] = false;
       }
 
-      const config_t generic_hdr_config = {1920, 1080, 60, 1000, 1, 0, 3, 1, 1, 0};
+      const config_t generic_hdr_config = {1920, 1080, 60, 6000, 1000, 1, 0, 3, 1, 1, 0};
 
       // Reset the display since we're switching from SDR to HDR. Keep probing on the
       // current active display without attempting a display swap.


### PR DESCRIPTION
## Summary

- Commit 43c6b42e ("revert AI regression") accidentally reverted the `framerateX100` initializer fix from 5d6b4a8f, causing all `config_t` probe literals to have their fields shifted by one position
- The `bitrate` field receives a value of `1` (kbps) instead of `1000`, producing a final bitrate of just 1000 bps
- This causes QSV (and potentially other hardware encoders) to fail probe with "invalid video parameters (-15)"
- Affected GPUs include Intel Arc (A770 confirmed), which should use QSV but falls back to software encoding instead

## Test plan

- [ ] Verify QSV encoder probe passes on Intel Arc GPU (probe log should show "Streaming bitrate is 1000000" instead of "Streaming bitrate is 1000")
- [ ] Verify NVENC/AMDvce probes are unaffected on NVIDIA/AMD GPUs
- [ ] Verify HDR and YUV444 probe configs also use correct bitrate